### PR TITLE
Show loading indicator while setting up player

### DIFF
--- a/lib/domain/asset.dart
+++ b/lib/domain/asset.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:better_player/better_player.dart';
+import 'package:flutter/material.dart';
 
 import '../models/asset.dart';
 
@@ -16,6 +17,7 @@ BetterPlayerConfiguration getPlayerConfiguration() {
     controlsConfiguration: BetterPlayerControlsConfiguration(
       enablePlayPause: true,
       enableFullscreen: true,
+      loadingColor: Colors.blue,
     ),
   );
 }

--- a/lib/widgets/player.dart
+++ b/lib/widgets/player.dart
@@ -49,7 +49,9 @@ class _TPStreamPlayerState extends State<TPStreamPlayer> {
           } else if (snapshot.hasError) {
             return Text(snapshot.error.toString());
           } else {
-            return const Text("Loading");
+            return const Center(
+              child: CircularProgressIndicator(),
+            );
           }
         });
   }


### PR DESCRIPTION
- Showed a loading indicator instead of just showing "Loading" while setting up the player with the fetched asset.
- Changed the player loading indicator color to match our design, now in blue."