### PR TITLE
Fix DRM videos not playing on iOS devices

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,9 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.1.0
-  better_player: ^0.0.83
+  better_player:
+    git: https://github.com/harinath01/betterplayer
+    ref: main
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Currently, the better_player package doesn't have FairPlay DRM support, so we forked it and added that support, and used it as a dependency.