### PR TITLE
fix: Multiple audio plays in background after fullscreen toggle

### DIFF
--- a/lib/domain/asset.dart
+++ b/lib/domain/asset.dart
@@ -4,11 +4,6 @@ import 'package:better_player/better_player.dart';
 
 import '../models/asset.dart';
 
-BetterPlayerController getPlayerControllerForAsset(Asset asset) {
-  return BetterPlayerController(getPlayerConfiguration(),
-      betterPlayerDataSource: getDataSource(asset));
-}
-
 BetterPlayerConfiguration getPlayerConfiguration() {
   return const BetterPlayerConfiguration(
     autoPlay: true,

--- a/lib/widgets/player.dart
+++ b/lib/widgets/player.dart
@@ -28,6 +28,7 @@ class _TPStreamPlayerState extends State<TPStreamPlayer> {
   void initState() {
     super.initState();
     _assetFuture = fetchAsset(widget.assetId, widget.accessToken);
+    _controller = BetterPlayerController(getPlayerConfiguration());
   }
 
   @override
@@ -41,7 +42,9 @@ class _TPStreamPlayerState extends State<TPStreamPlayer> {
         future: _assetFuture,
         builder: (context, snapshot) {
           if (snapshot.hasData) {
-            _controller = getPlayerControllerForAsset(snapshot.data as Asset);
+            _controller.setupDataSource(
+                getDataSource(snapshot.data as Asset)
+            );
             return AspectRatio(
               aspectRatio: 16 / 9,
               child: BetterPlayer(controller: _controller),


### PR DESCRIPTION
- Previously, the Better Player Controller was being initialized within the TPStreamPlayer widget's build method. This led to a situation where, upon widget rebuild, a new controller would be initialized without properly cleaning up the previous controller. As a result, audio continued to be sourced from the previous controller.
- This is fixed in this commit by setting the data source on the controller when it is fetched from the server and initializing the controller only one-time initState method.